### PR TITLE
Fix footer links in default.hbs

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -82,13 +82,13 @@
         <nav id="footer-nav" role="navigation">
             <ul id="footer-menu">
                 <li class="logo"><a href="/"><img alt="Ghost" src="//ghost.org/assets/logo-minighost-0f5476cf6a52adff2f2a67e4f16d3e29.png"></a></li>
-                <li><a class="" href="/about/">About</a></li>
+                <li><a class="" href="//ghost.org//about/">About</a></li>
                 <li><a href="http://status.ghost.org">Status</a></li>
-                <li><a class="" href="/pricing/">Pricing</a></li>
+                <li><a class="" href="//ghost.org/pricing/">Pricing</a></li>
                 <li><a href="http://blog.ghost.org">Blog</a></li>
-                <li><a class="" href="/about/terms/">Terms</a></li>
-                <li><a class="" href="/about/privacy/">Privacy</a></li>
-                <li><a class="" href="/about/contact/">Contact</a></li>
+                <li><a class="" href="//ghost.org//about/terms/">Terms</a></li>
+                <li><a class="" href="//ghost.org//about/privacy/">Privacy</a></li>
+                <li><a class="" href="//ghost.org//about/contact/">Contact</a></li>
             </ul>
             <div class="clearfix"></div>
 


### PR DESCRIPTION
When inside the blog clicking on procing, about, or contact links in the footer will result in 404 page, because they're linked to the current domain (which is blog.ghost.org) and they're existing on the main domain (ghost.org).