### PR TITLE
Asset update

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -12,11 +12,11 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="shortcut icon" type="image/x-icon" href="//ghost.org/assets/favicon-e13fe17b11ad125601924cfb260f20da.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="https://ghost.org/assets/favicon-e13fe17b11ad125601924cfb260f20da.ico">
 
     {{! Styles'n'Scripts }}
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:700,400,200" />
-    <link rel="stylesheet" href="//ghost.org/assets/application-4429d994692ff98725ab40f22273d956.css" media="all" rel="stylesheet">
+    <link rel="stylesheet" href="https://ghost.org/assets/application-53c891abfa2c2305e65de0c84c76e9e1.css" media="all" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
 
     <meta property="twitter:site" content="@TryGhost">
@@ -81,7 +81,7 @@
     <footer id="global-footer">
         <nav id="footer-nav" role="navigation">
             <ul id="footer-menu">
-                <li class="logo"><a href="/"><img alt="Ghost" src="//ghost.org/assets/logo-minighost-0f5476cf6a52adff2f2a67e4f16d3e29.png"></a></li>
+                <li class="logo"><a href="/"><img alt="Ghost" src="https://ghost.org/assets/logo-minighost-0f5476cf6a52adff2f2a67e4f16d3e29.png"></a></li>
                 <li><a class="" href="//ghost.org/about/">About</a></li>
                 <li><a href="http://status.ghost.org">Status</a></li>
                 <li><a class="" href="//ghost.org/pricing/">Pricing</a></li>
@@ -92,7 +92,7 @@
             </ul>
             <div class="clearfix"></div>
 
-            <span class="poweredby"><img alt="Ghost" src="//ghost.org/assets/logo-minidigitalocean-1bb39c0755ac79befc56ca39d7889eb5.png"> Powered <em>by</em> <a href="https://digitalocean.com" target="_blank">DigitalOcean</a></span>
+            <span class="poweredby"><img alt="Ghost" src="https://ghost.org/assets/logo-minidigitalocean-1bb39c0755ac79befc56ca39d7889eb5.png"> Powered <em>by</em> <a href="https://digitalocean.com" target="_blank">DigitalOcean</a></span>
 
             <ul id="social-menu">
                 <li class="github"><a href="https://github.com/tryghost/Ghost"><span class="hidden">Github</span></a></li>
@@ -117,7 +117,7 @@
     </script>
     <script src="https://ghost.org/navigation/"></script>
 
-    <script type="text/javascript" src="//ghost.org/assets/application-b3c32be93105ff710a7fd776dff06d70.js"></script>
+    <script type="text/javascript" src="https://ghost.org/assets/application-f70a08abb1fd9fbfdd4ae25ddd2c3d6b.js"></script>
     <script type="text/javascript" src="{{asset "js/jquery.fitvids.js"}}"></script>
     <script type="text/javascript" src="{{asset "js/prism.js"}}"></script>
     <script type="text/javascript" src="{{asset "js/index.js"}}"></script>

--- a/page.hbs
+++ b/page.hbs
@@ -6,7 +6,7 @@
         <article class="{{post_class}}">
             {{#post}}
 
-            <a class="post-meta" href="/">&larr; Back to the front page</a>
+            <a class="post-meta" href="{{@blog.url}}">&larr; Back to the front page</a>
 
             <h1 class="post-title">{{{title}}}</h1>
 

--- a/post.hbs
+++ b/post.hbs
@@ -6,7 +6,7 @@
         <article class="{{post_class}}">
         {{#post}}
 
-            <a class="post-meta" href="/">&larr; Back to the front page</a>
+            <a class="post-meta" href="{{@blog.url}}">&larr; Back to the front page</a>
 
             <h1 class="post-title">{{{title}}}</h1>
             <section class="post-meta">


### PR DESCRIPTION
Chucked two little commits into this 1 PR:

- updating the asset URLs to reference more recent versions and also switch all the ghost.org/assets/ urls to explicitly use https as by using the scheme-less version, we end up with a redirect whenever accessing these assets from http.
- fixing up the back links to use `{{@blog.url}}` so that it works on a subdir (as I have on my local test env)