### PR TITLE
fixing mistype of disqus_shortname variable

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -80,7 +80,7 @@
             <section class="comments">
                 <div id="disqus_thread"></div>
                 <script type="text/javascript">
-                    var disqus_identifier = 'ghost-{{id}}';
+                    var disqus_shortname = 'ghost-{{id}}';
                     (function() {
                         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
                         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
The javascript variable for ```disqus_shortname``` is attempted to be used in the code copied from Disqus, but the variable defined is ```disqus_identifier```. This PR is fixing this typo.