### PR TITLE
Fix 'Read the full post >>' links on mis-tagged posts

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -26,7 +26,7 @@
                                         {{img_url feature_image size="xl"}} 2000w" sizes="(max-width: 1000px) 400px, 700px" src="{{img_url feature_image size="m"}}" alt="{{title}}"
                             />
                             <p>{{excerpt}}</p>
-                            <div class="readmore">Read the full post &raquo;</div>
+                            <a {{#if canonical_url}}href="{{canonical_url}}" target="_blank" rel="noopener" {{else}}href="{{url}}" {{/if}}><div class="readmore">Read the full post &raquo;</div></a>
                         {{else}}
                             {{content}}
                         {{/if}}

--- a/index.hbs
+++ b/index.hbs
@@ -26,7 +26,6 @@
                                         {{img_url feature_image size="xl"}} 2000w" sizes="(max-width: 1000px) 400px, 700px" src="{{img_url feature_image size="m"}}" alt="{{title}}"
                             />
                             <p>{{excerpt}}</p>
-                            <a {{#if canonical_url}}href="{{canonical_url}}" target="_blank" rel="noopener" {{else}}href="{{url}}" {{/if}}><div class="readmore">Read the full post &raquo;</div></a>
                         {{else}}
                             {{content}}
                         {{/if}}


### PR DESCRIPTION
With the new changelog feed I found that an incorrectly tagged post had a `Read the full post >>` link which was unclickable.

This PR would allow the `Read the full post >>` link to be clickable (but not the whole changelog item).